### PR TITLE
feat: view perf I

### DIFF
--- a/packages/db/README.md
+++ b/packages/db/README.md
@@ -24,4 +24,3 @@ To spinup the local DB run
 ```bash
 pnpm --filter @ashgw/db start
 ```
-

--- a/packages/db/prisma/migrations/20250827230126_add_viewdayutc_nullable/migration.sql
+++ b/packages/db/prisma/migrations/20250827230126_add_viewdayutc_nullable/migration.sql
@@ -1,0 +1,32 @@
+-- DropIndex
+DROP INDEX "PostView_createdAt_idx";
+
+-- DropIndex
+DROP INDEX "PostView_postSlug_fingerprint_createdAt_idx";
+
+-- AlterTable
+ALTER TABLE "Post" ADD COLUMN     "viewsTotal" INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
+ALTER TABLE "PostView" ADD COLUMN     "viewDayUTC" TIMESTAMP(3);
+
+-- CreateTable
+CREATE TABLE "PostViewDaily" (
+    "postSlug" VARCHAR(255) NOT NULL,
+    "day" TIMESTAMP(3) NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "PostViewDaily_pkey" PRIMARY KEY ("postSlug","day")
+);
+
+-- CreateIndex
+CREATE INDEX "PostViewDaily_day_idx" ON "PostViewDaily"("day");
+
+-- CreateIndex
+CREATE INDEX "PostView_postSlug_createdAt_idx" ON "PostView"("postSlug", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "PostView_postSlug_viewDayUTC_idx" ON "PostView"("postSlug", "viewDayUTC");
+
+-- CreateIndex
+CREATE INDEX "PostView_viewDayUTC_idx" ON "PostView"("viewDayUTC");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -11,33 +11,50 @@ datasource db {
 }
 
 model Post {
-  slug          String     @id @db.VarChar(255)
-  title         String     @db.VarChar(30)
-  seoTitle      String     @db.VarChar(100)
-  summary       String     @db.VarChar(100)
-  firstModDate  DateTime   @default(now())
-  lastModDate   DateTime   @updatedAt
-  isReleased    Boolean
-  minutesToRead Int        @db.SmallInt
-  tags          String[]   @db.VarChar(255)
-  category      PostCategory
-  mdxContentId  String     @unique @db.VarChar(255)
-  mdxContent    Upload     @relation("PostMdxContent", fields: [mdxContentId], references: [key], onDelete: Cascade)
-  postViews     PostView[] @relation("PostViews")
+  slug           String           @id @db.VarChar(255)
+  title          String           @db.VarChar(30)
+  seoTitle       String           @db.VarChar(100)
+  summary        String           @db.VarChar(100)
+  firstModDate   DateTime         @default(now())
+  lastModDate    DateTime         @updatedAt
+  isReleased     Boolean
+  minutesToRead  Int              @db.SmallInt
+  tags           String[]         @db.VarChar(255)
+  category       PostCategory
+  mdxContentId   String           @unique @db.VarChar(255)
+  mdxContent     Upload           @relation("PostMdxContent", fields: [mdxContentId], references: [key], onDelete: Cascade)
+  postViews      PostView[]       @relation("PostViews")
+  viewsTotal     Int              @default(0)
+  postViewsDaily PostViewDaily[]  @relation("PostViewsDaily")
 
   @@index([mdxContentId])
 }
 
 model PostView {
-  id          String   @id @default(cuid())
-  postSlug    String   @db.VarChar(255)
-  fingerprint String   @db.VarChar(64)  // Contains hashed postSlug:ip:userAgent
-  createdAt   DateTime @default(now())
-  post        Post     @relation("PostViews", fields: [postSlug], references: [slug], onDelete: Cascade)
+  id           String   @id @default(cuid())
+  postSlug     String   @db.VarChar(255)
+  fingerprint  String   @db.VarChar(64)  // Contains hashed postSlug:ip:userAgent
+  createdAt    DateTime @default(now())
+  post         Post     @relation("PostViews", fields: [postSlug], references: [slug], onDelete: Cascade)
+  // calendar day boundary at 00:00 UTC for dedupe
+  viewDayUTC   DateTime
 
   @@index([postSlug, fingerprint, createdAt])
   @@index([createdAt])
   @@index([fingerprint])
+  // one row per (post, fingerprint) per day
+  @@unique([postSlug, fingerprint, viewDayUTC], name: "unique_daily_view")
+}
+
+// daily rollup for charts
+model PostViewDaily {
+  postSlug String   @db.VarChar(255)
+  post     Post     @relation("PostViewsDaily", fields: [postSlug], references: [slug], onDelete: Cascade)
+  day      DateTime // 00:00:00 UTC
+  count    Int      @default(0)
+
+  @@id([postSlug, day])
+  @@index([day])
 }
 
 model Upload {
@@ -50,14 +67,14 @@ model Upload {
 }
 
 model User {
-  id            String    @id @default(cuid())
-  email         String    @unique @db.VarChar(255)
-  name          String    @db.VarChar(30)
-  passwordHash  String    @db.VarChar(1024)
-  role          UserRole  @default(VISITOR)
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
-  sessions      Session[]
+  id           String    @id @default(cuid())
+  email        String    @unique @db.VarChar(255)
+  name         String    @db.VarChar(30)
+  passwordHash String    @db.VarChar(1024)
+  role         UserRole  @default(VISITOR)
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+  sessions     Session[]
 }
 
 model Session {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -24,8 +24,8 @@ model Post {
   mdxContentId   String           @unique @db.VarChar(255)
   mdxContent     Upload           @relation("PostMdxContent", fields: [mdxContentId], references: [key], onDelete: Cascade)
   postViews      PostView[]       @relation("PostViews")
-  viewsTotal     Int              @default(0)
   postViewsDaily PostViewDaily[]  @relation("PostViewsDaily")
+  viewsTotal     Int              @default(0)
 
   @@index([mdxContentId])
 }
@@ -33,20 +33,20 @@ model Post {
 model PostView {
   id           String   @id @default(cuid())
   postSlug     String   @db.VarChar(255)
-  fingerprint  String   @db.VarChar(64)  // Contains hashed postSlug:ip:userAgent
+  fingerprint  String   @db.VarChar(64)
   createdAt    DateTime @default(now())
+  viewDayUTC   DateTime?   // <- temporarily optional
   post         Post     @relation("PostViews", fields: [postSlug], references: [slug], onDelete: Cascade)
-  // calendar day boundary at 00:00 UTC for dedupe
-  viewDayUTC   DateTime
 
-  @@index([postSlug, fingerprint, createdAt])
-  @@index([createdAt])
+  @@index([postSlug, createdAt])
+  @@index([postSlug, viewDayUTC])
+  @@index([viewDayUTC])
   @@index([fingerprint])
-  // one row per (post, fingerprint) per day
-  @@unique([postSlug, fingerprint, viewDayUTC], name: "unique_daily_view")
+  // @@unique([postSlug, fingerprint, viewDayUTC], name: "unique_daily_view")  // <- TODO: comment out for pass 1 & add the other migration
 }
 
-// daily rollup for charts
+
+// daily rollup for charts and totals
 model PostViewDaily {
   postSlug String   @db.VarChar(255)
   post     Post     @relation("PostViewsDaily", fields: [postSlug], references: [slug], onDelete: Cascade)
@@ -61,7 +61,7 @@ model Upload {
   key         String       @id @db.VarChar(512)
   type        UploadType
   entityType  ResourceType @default(POST)
-  contentType String       @db.VarChar(100) // like image/png or whatever
+  contentType String       @db.VarChar(100)
   uploadedAt  DateTime     @default(now())
   post        Post?        @relation("PostMdxContent")
 }


### PR DESCRIPTION
The pull request introduces an initial database schema setup and includes a specific feature to handle nullable fields in a view. The `schema.prisma` file within the `packages/db/prisma` directory has been updated to define the initial structure of the database, which likely includes the foundational models and their relationships, although the exact details of these models are not visible in the diff summary. Additionally, a new migration script named `20250827230126_add_viewdayutc_nullable/migration.sql` has been added, which suggests that it contains SQL commands to alter the database schema, specifically making a field related to "view UTC" nullable. This change indicates an enhancement to the database schema to accommodate optional data for a particular view, likely improving flexibility in data storage and retrieval. The `README.md` file in the `packages/db` directory has also been modified, which typically involves updates to documentation to reflect changes in the database setup or usage instructions, ensuring that developers have the necessary information to work with the updated schema. Overall, this pull request sets up the foundational database schema and introduces a specific enhancement to handle nullable fields, preparing the system for further development and data handling capabilities.
  
  
  

<sub>Generated by [pr-summarizer](https://github.com/ashgw/pr-summarizer)</sub>